### PR TITLE
chore: update workspaces configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "workspaces": [
     "tooling/*",
-    "packages/**",
+    "packages/*",
+    "packages/@chakra-icons/*",
     "website",
     "!website/**",
     "!tooling/cli/**",


### PR DESCRIPTION
Prefer to use `"packages/*"` than `"packages/**"` cause have problem when `clone` some project and listed in `@chakra-icons/project/X`. `yarn workspaces` will be treat like our projects.