### PR TITLE
feat(create-chakra-icons): ability to set output specific #10

### DIFF
--- a/packages/create-chakra-icons/README.md
+++ b/packages/create-chakra-icons/README.md
@@ -46,6 +46,13 @@ create-chakra-icons [FLAGS] [OPTIONS] [INPUT]
 -P, --prefix <STRING>   Sets for prefix in export named declaration.
                         [e.g.: -S "Icon"]
 --ts, --typescript      Sets output as TypeScript code.
+
+-T, --type <TYPE>       TYPE:
+                        (F|f). Sets output code with function \`createIcon({...})\`.
+                        (C|c). Sets output code with Component Icon \`(props) => <Icon> {...} </Icon>\`.
+
+                        [e.g.: -T C]
+
 ```
 
 ### Input

--- a/packages/create-chakra-icons/lib/chakra.js
+++ b/packages/create-chakra-icons/lib/chakra.js
@@ -25,7 +25,7 @@ const ast = require("./ast");
 const createChakraIcon = (...sources) => {
   // eslint-disable-next-line no-shadow
   const isTypescript = sources.some(({ isTypescript }) => isTypescript);
-  const perFileCode = ({ source: svg, displayName }) => {
+  const perFileCode = ({ source: svg, displayName, outputType }) => {
     const hast = SvgParser.parse(svg);
     // This for solve issue {https://github.com/kodingdotninja/create-chakra-icons/issues/7}
     // In the issue 7, have some example svg file at examples/issue7.svg
@@ -38,11 +38,16 @@ const createChakraIcon = (...sources) => {
       }
       return false;
     })();
-    if (ast.hastChildrenLength(hast) > 1 || isNotTagnamePath) {
+
+    const outputWithCreateIcon = outputType.toLowerCase() === "f";
+
+    const outputWithIcon = outputType.toLowerCase() === "c" || ast.hastChildrenLength(hast) > 1 || isNotTagnamePath;
+
+    if (outputWithIcon && !outputWithCreateIcon) {
       return ast.hastToComponent(hast, { displayName, isTypescript });
     }
 
-    const properties = ast.hastToProperties(hast);
+    const properties = outputWithIcon ? ast.hastToProperties2(hast) : ast.hastToProperties(hast);
 
     const objectExpression = ast.objectToObjectExpression({
       displayName,
@@ -53,6 +58,7 @@ const createChakraIcon = (...sources) => {
       displayName,
       objectExpression: [objectExpression],
     });
+
     return iconAST;
   };
   const svgCodes = [...sources].map(perFileCode);


### PR DESCRIPTION
Solved Feature Request from #10 

### Usage
```console
create-chakra-icons path/to/file.svg -T f
// output will be
// createIcon({...})

create-chakra-icons path/to/file.svg -T c
// output will be
// props => <Icon>({...})</Icon>
```

