### PR TITLE
prepack for all packages in @chakra-icons

### DIFF
--- a/packages/@chakra-icons/bootstrap/package.json
+++ b/packages/@chakra-icons/bootstrap/package.json
@@ -20,12 +20,6 @@
     "dist/",
     "src/"
   ],
-  "scripts": {
-    "build": "chakra-icons build -r 'https://github.com/twbs/icons' -n bootstrap -i icons -S snapshot.json -E",
-    "clean": "chakra-icons clean -r 'https://github.com/twbs/icons' -n bootstrap -i icons",
-    "format": "prettier --write README.md snapshot.json",
-    "postbuild": "tsup && yarn format"
-  },
   "devDependencies": {
     "@chakra-ui/react": "^1",
     "@chakra-icons/cli": "1.0.1",
@@ -38,5 +32,12 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "chakra-icons build -r 'https://github.com/twbs/icons' -n bootstrap -i icons -S snapshot.json -E",
+    "clean": "chakra-icons clean -r 'https://github.com/twbs/icons' -n bootstrap -i icons",
+    "format": "prettier --write README.md snapshot.json",
+    "postbuild": "tsup && yarn format",
+    "prepack": "chakra-icons prepack --remove-dev-deps"
   }
 }

--- a/packages/@chakra-icons/carbon/package.json
+++ b/packages/@chakra-icons/carbon/package.json
@@ -20,12 +20,6 @@
     "dist/",
     "src/"
   ],
-  "scripts": {
-    "build": "chakra-icons build -r 'https://github.com/carbon-design-system/carbon-icons' -n carbon -i src/svg -S snapshot.json -E",
-    "clean": "chakra-icons clean -r 'https://github.com/carbon-design-system/carbon-icons' -n carbon -i src/svg",
-    "format": "prettier --write README.md snapshot.json",
-    "postbuild": "tsup && yarn format"
-  },
   "devDependencies": {
     "@chakra-ui/react": "^1",
     "@chakra-icons/cli": "1.0.1",
@@ -38,5 +32,12 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "chakra-icons build -r 'https://github.com/carbon-design-system/carbon-icons' -n carbon -i src/svg -S snapshot.json -E",
+    "clean": "chakra-icons clean -r 'https://github.com/carbon-design-system/carbon-icons' -n carbon -i src/svg",
+    "format": "prettier --write README.md snapshot.json",
+    "postbuild": "tsup && yarn format",
+    "prepack": "chakra-icons prepack --remove-dev-deps"
   }
 }

--- a/packages/@chakra-icons/cryptocurrency-icons/package.json
+++ b/packages/@chakra-icons/cryptocurrency-icons/package.json
@@ -20,12 +20,6 @@
     "dist/",
     "src/"
   ],
-  "scripts": {
-    "build": "chakra-icons build -r 'https://github.com/spothq/cryptocurrency-icons' -n cryptocurrency-icons -i svg/color -S snapshot.json -E",
-    "clean": "chakra-icons clean -r 'https://github.com/spothq/cryptocurrency-icons' -n cryptocurrency-icons -i svg/color",
-    "format": "prettier --write README.md snapshot.json",
-    "postbuild": "tsup && yarn format"
-  },
   "devDependencies": {
     "@chakra-ui/react": "^1",
     "@chakra-icons/cli": "1.0.1",
@@ -38,5 +32,12 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "chakra-icons build -r 'https://github.com/spothq/cryptocurrency-icons' -n cryptocurrency-icons -i svg/color -S snapshot.json -E",
+    "clean": "chakra-icons clean -r 'https://github.com/spothq/cryptocurrency-icons' -n cryptocurrency-icons -i svg/color",
+    "format": "prettier --write README.md snapshot.json",
+    "postbuild": "tsup && yarn format",
+    "prepack": "chakra-icons prepack --remove-dev-deps"
   }
 }

--- a/packages/@chakra-icons/feather/package.json
+++ b/packages/@chakra-icons/feather/package.json
@@ -20,12 +20,6 @@
     "dist/",
     "src/"
   ],
-  "scripts": {
-    "build": "chakra-icons build -r 'https://github.com/feathericons/feather' -n feather -i icons -S snapshot.json -E",
-    "clean": "chakra-icons clean -r 'https://github.com/feathericons/feather' -n feather -i icons",
-    "format": "prettier --write README.md snapshot.json",
-    "postbuild": "tsup && yarn format"
-  },
   "devDependencies": {
     "@chakra-ui/react": "^1",
     "@chakra-icons/cli": "1.0.1",
@@ -38,5 +32,12 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "chakra-icons build -r 'https://github.com/feathericons/feather' -n feather -i icons -S snapshot.json -E",
+    "clean": "chakra-icons clean -r 'https://github.com/feathericons/feather' -n feather -i icons",
+    "format": "prettier --write README.md snapshot.json",
+    "postbuild": "tsup && yarn format",
+    "prepack": "chakra-icons prepack --remove-dev-deps"
   }
 }

--- a/packages/@chakra-icons/flat-icon/package.json
+++ b/packages/@chakra-icons/flat-icon/package.json
@@ -20,12 +20,6 @@
     "dist/",
     "src/"
   ],
-  "scripts": {
-    "build": "chakra-icons build -r 'https://github.com/icons8/flat-color-icons' -n flat-icon -i svg -S snapshot.json -E",
-    "clean": "chakra-icons clean -r 'https://github.com/icons8/flat-color-icons' -n flat-icon -i svg",
-    "format": "prettier --write README.md snapshot.json",
-    "postbuild": "tsup && yarn format"
-  },
   "devDependencies": {
     "@chakra-ui/react": "^1",
     "@chakra-icons/cli": "1.0.1",
@@ -38,5 +32,12 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "chakra-icons build -r 'https://github.com/icons8/flat-color-icons' -n flat-icon -i svg -S snapshot.json -E",
+    "clean": "chakra-icons clean -r 'https://github.com/icons8/flat-color-icons' -n flat-icon -i svg",
+    "format": "prettier --write README.md snapshot.json",
+    "postbuild": "tsup && yarn format",
+    "prepack": "chakra-icons prepack --remove-dev-deps"
   }
 }

--- a/packages/@chakra-icons/ionicons/package.json
+++ b/packages/@chakra-icons/ionicons/package.json
@@ -20,12 +20,6 @@
     "dist/",
     "src/"
   ],
-  "scripts": {
-    "build": "chakra-icons build -r 'https://github.com/ionic-team/ionicons' -n ionicons -i src/svg -S snapshot.json -E",
-    "clean": "chakra-icons clean -r 'https://github.com/ionic-team/ionicons' -n ionicons -i src/svg",
-    "format": "prettier --write README.md snapshot.json",
-    "postbuild": "tsup && yarn format"
-  },
   "devDependencies": {
     "@chakra-ui/react": "^1",
     "@chakra-icons/cli": "1.0.1",
@@ -38,5 +32,12 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "chakra-icons build -r 'https://github.com/ionic-team/ionicons' -n ionicons -i src/svg -S snapshot.json -E",
+    "clean": "chakra-icons clean -r 'https://github.com/ionic-team/ionicons' -n ionicons -i src/svg",
+    "format": "prettier --write README.md snapshot.json",
+    "postbuild": "tsup && yarn format",
+    "prepack": "chakra-icons prepack --remove-dev-deps"
   }
 }

--- a/packages/@chakra-icons/octicons/package.json
+++ b/packages/@chakra-icons/octicons/package.json
@@ -20,12 +20,6 @@
     "dist/",
     "src/"
   ],
-  "scripts": {
-    "build": "chakra-icons build -r 'https://github.com/primer/octicons' -n octicons -i icons -S snapshot.json -E",
-    "clean": "chakra-icons clean -r 'https://github.com/primer/octicons' -n octicons -i icons",
-    "format": "prettier --write README.md snapshot.json",
-    "postbuild": "tsup && yarn format"
-  },
   "devDependencies": {
     "@chakra-ui/react": "^1",
     "@chakra-icons/cli": "1.0.1",
@@ -38,5 +32,12 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "chakra-icons build -r 'https://github.com/primer/octicons' -n octicons -i icons -S snapshot.json -E",
+    "clean": "chakra-icons clean -r 'https://github.com/primer/octicons' -n octicons -i icons",
+    "format": "prettier --write README.md snapshot.json",
+    "postbuild": "tsup && yarn format",
+    "prepack": "chakra-icons prepack --remove-dev-deps"
   }
 }

--- a/packages/@chakra-icons/simple-line-icons/package.json
+++ b/packages/@chakra-icons/simple-line-icons/package.json
@@ -20,12 +20,6 @@
     "dist/",
     "src/"
   ],
-  "scripts": {
-    "build": "chakra-icons build -r 'https://github.com/thesabbir/simple-line-icons' -n simple-line-icons -i src/svgs -S snapshot.json -E",
-    "clean": "chakra-icons clean -r 'https://github.com/thesabbir/simple-line-icons' -n simple-line-icons -i src/svgs",
-    "format": "prettier --write README.md snapshot.json",
-    "postbuild": "tsup && yarn format"
-  },
   "devDependencies": {
     "@chakra-ui/react": "^1",
     "@chakra-icons/cli": "1.0.1",
@@ -38,5 +32,12 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "chakra-icons build -r 'https://github.com/thesabbir/simple-line-icons' -n simple-line-icons -i src/svgs -S snapshot.json -E",
+    "clean": "chakra-icons clean -r 'https://github.com/thesabbir/simple-line-icons' -n simple-line-icons -i src/svgs",
+    "format": "prettier --write README.md snapshot.json",
+    "postbuild": "tsup && yarn format",
+    "prepack": "chakra-icons prepack --remove-dev-deps"
   }
 }

--- a/packages/@chakra-icons/tabler-icons/package.json
+++ b/packages/@chakra-icons/tabler-icons/package.json
@@ -20,12 +20,6 @@
     "dist/",
     "src/"
   ],
-  "scripts": {
-    "build": "chakra-icons build -r 'tabler/tabler-icons' -n tabler-icons -i icons -S snapshot.json -E",
-    "clean": "chakra-icons clean -r 'tabler/tabler-icons' -n tabler-icons -i icons",
-    "format": "prettier --write README.md snapshot.json",
-    "postbuild": "tsup && yarn format"
-  },
   "devDependencies": {
     "@chakra-ui/react": "^1",
     "@chakra-icons/cli": "1.0.1",
@@ -38,5 +32,12 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "chakra-icons build -r 'tabler/tabler-icons' -n tabler-icons -i icons -S snapshot.json -E",
+    "clean": "chakra-icons clean -r 'tabler/tabler-icons' -n tabler-icons -i icons",
+    "format": "prettier --write README.md snapshot.json",
+    "postbuild": "tsup && yarn format",
+    "prepack": "chakra-icons prepack --remove-dev-deps"
   }
 }

--- a/packages/@chakra-icons/typicons/package.json
+++ b/packages/@chakra-icons/typicons/package.json
@@ -20,12 +20,6 @@
     "dist/",
     "src/"
   ],
-  "scripts": {
-    "build": "chakra-icons build -r 'https://github.com/stephenhutchings/typicons.font' -n typicons -i src/svg -S snapshot.json -E",
-    "clean": "chakra-icons clean -r 'https://github.com/stephenhutchings/typicons.font' -n typicons -i src/svg",
-    "format": "prettier --write README.md snapshot.json",
-    "postbuild": "tsup && yarn format"
-  },
   "devDependencies": {
     "@chakra-ui/react": "^1",
     "@chakra-icons/cli": "1.0.1",
@@ -38,5 +32,12 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "chakra-icons build -r 'https://github.com/stephenhutchings/typicons.font' -n typicons -i src/svg -S snapshot.json -E",
+    "clean": "chakra-icons clean -r 'https://github.com/stephenhutchings/typicons.font' -n typicons -i src/svg",
+    "format": "prettier --write README.md snapshot.json",
+    "postbuild": "tsup && yarn format",
+    "prepack": "chakra-icons prepack --remove-dev-deps"
   }
 }


### PR DESCRIPTION
## Changes
- chore(bootstrap): remove dev deps when packing package
- chore(carbon): remove dev deps when packing package
- chore(cryptocurrency-icons): remove dev deps when packing package
- chore(feather): remove dev deps when packing package
- chore(flat-icon): remove dev deps when packing package
- chore(ionicons): remove dev deps when packing package
- chore(octicons): remove dev deps when packing package
- chore(simple-line-icons): remove dev deps when packing package
- chore(tabler-icons): remove dev deps when packing package
- chore(typicons): remove dev deps when packing package


## What happened when run pack `yarn pack` or `npm pack`

`pack` both yarn or npm we apply the hooks of `prepack` in field `scripts` at package.json. 

So, Every package berfore packaging and publish will remove devDependencies 

> Proof
<img width="1386" alt="image" src="https://user-images.githubusercontent.com/16365952/175985251-8bd56b05-10b2-488d-ad34-21efd4aac3ac.png">

## Goals

Remove **Dev Dependencies (4)** in npm (e.g: https://www.npmjs.com/package/@chakra-icons/bootstrap)
<img width="1422" alt="image" src="https://user-images.githubusercontent.com/16365952/175985803-1c3d3e42-6596-4731-88c0-ec3e252b0c22.png">


## Merge Strategy

When thie PRs approved, so **Rebase and Merge** is better strategy for merge. Because we want to show all commit in **main** branch. Then, release ci will trigger each packages.