### PR TITLE
Add new parameters ability to set: write file with append mode, output without import code, use filename as display name

### DIFF
--- a/packages/create-chakra-icons/lib/chakra.js
+++ b/packages/create-chakra-icons/lib/chakra.js
@@ -25,6 +25,9 @@ const ast = require("./ast");
 const createChakraIcon = (...sources) => {
   // eslint-disable-next-line no-shadow
   const isTypescript = sources.some(({ isTypescript }) => isTypescript);
+  // eslint-disable-next-line no-shadow
+  const isIgnoreImport = sources.some(({ isIgnoreImport }) => isIgnoreImport);
+
   const perFileCode = ({ source: svg, displayName, outputType }) => {
     const hast = SvgParser.parse(svg);
     // This for solve issue {https://github.com/kodingdotninja/create-chakra-icons/issues/7}
@@ -62,6 +65,10 @@ const createChakraIcon = (...sources) => {
     return iconAST;
   };
   const svgCodes = [...sources].map(perFileCode);
+
+  if (isIgnoreImport) {
+    return ast.toSource(...svgCodes);
+  }
 
   const hasVariableDeclaratorInit =
     (is) =>

--- a/packages/create-chakra-icons/lib/index.d.ts
+++ b/packages/create-chakra-icons/lib/index.d.ts
@@ -7,6 +7,9 @@ export type Option = {
   output?: string | undefined;
   ts?: boolean | undefined;
   typescript?: boolean | undefined;
+  useFilename?: boolean | undefined;
+  appendFile?: boolean | undefined;
+  ignoreImport?: boolean | undefined;
 }
 
 declare module "create-chakra-icons" {


### PR DESCRIPTION
1.  `--append-file` Sets output write file as append mode (*ONLY for output path provided).
2. `--ignore-import` Sets output without import statement.
3. `--use-filename` Sets use filename for export named declaration.
